### PR TITLE
Adds s2i java build example

### DIFF
--- a/s2i-build/java/README.md
+++ b/s2i-build/java/README.md
@@ -1,0 +1,20 @@
+# simple-camel-app
+Reference: https://github.com/monodot/simple-camel-spring-boot-app/tree/master
+
+To run:
+
+    mvn clean spring-boot:run
+    
+This will start a REST service on port 8080 using the embedded servlet container, Undertow:
+
+    $ curl http://localhost:8080/camel/hello
+    Hello world!
+
+Note that the default servlet path for Camel is `/camel`.
+
+**NB: Requires JDK 11** (for no good reason, other than I just wanted to test it out). So, ensure you're using JDK 11, e.g. with [sdkman][sdkman]:
+
+    sdk install java 11.0.9.hs-adpt
+    sdk use java 11.0.9.hs-adpt
+
+[sdkman]: https://sdkman.io/

--- a/s2i-build/java/buildspec.yml
+++ b/s2i-build/java/buildspec.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto8
+  build:
+    commands:
+      - echo Starting building a lovely Camel 🐫 on `date`
+      - mvn test 
+  post_build:
+    commands:
+      - echo Completed building a lovely Camel 🐫 on `date`
+      - mvn package
+artifacts:
+  files:
+    - target/simple-camel-spring-boot-app-1.0-SNAPSHOT.jar
+  discard-paths: yes

--- a/s2i-build/java/pom.xml
+++ b/s2i-build/java/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>xyz.tomd</groupId>
+    <artifactId>simple-camel-app</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.${revision}</version>
+
+    <name>Simple Camel App</name>
+    <description>A simple Camel app for testing and playing around with</description>
+
+    <!-- Required for Maven Release Plugin to work -->
+    <scm>
+        <developerConnection>scm:git:git@github.com:monodot/simple-camel-app.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <jkube.version>1.0.2</jkube.version>
+
+        <!-- Red Hat Fuse 7.8 on Spring Boot 2.x equivalent -->
+        <spring.boot-version>2.3.4.RELEASE</spring.boot-version>
+        <camel.version>2.23.2</camel.version>
+
+        <!-- A sensible default for the 'revision' property when running a local build -->
+        <revision>0-SNAPSHOT</revision>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Camel BOM -->
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-spring-boot-dependencies</artifactId>
+                <version>${camel.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-servlet-starter</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>openshift</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.eclipse.jkube</groupId>
+                        <artifactId>openshift-maven-plugin</artifactId>
+                        <version>${jkube.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>resource</goal>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/s2i-build/java/src/main/java/xyz/tomd/MySpringBootApplication.java
+++ b/s2i-build/java/src/main/java/xyz/tomd/MySpringBootApplication.java
@@ -1,0 +1,16 @@
+package xyz.tomd;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MySpringBootApplication {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(MySpringBootApplication.class, args);
+    }
+
+}

--- a/s2i-build/java/src/main/java/xyz/tomd/MySpringBootRouter.java
+++ b/s2i-build/java/src/main/java/xyz/tomd/MySpringBootRouter.java
@@ -1,0 +1,15 @@
+package xyz.tomd;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MySpringBootRouter extends RouteBuilder {
+
+    @Override
+    public void configure() {
+        from("servlet:/hello")
+                .setBody(constant("Hello world!"));
+    }
+
+}

--- a/s2i-build/java/src/main/resources/application.properties
+++ b/s2i-build/java/src/main/resources/application.properties
@@ -1,0 +1,32 @@
+
+# the name of Camel
+camel.springboot.name = MyCamel
+
+# what to say
+greeting = Hello World
+
+# how often to trigger the timer
+timer.period = 2000
+
+# to automatic shutdown the JVM after a period of time
+#camel.springboot.duration-max-seconds=60
+#camel.springboot.duration-max-messages=100
+
+# add for example: &repeatCount=5 to the timer endpoint to make Camel idle
+#camel.springboot.duration-max-idle-seconds=15
+
+# expose actuator endpoint via HTTP
+management.endpoints.web.exposure.include=info,health,camelroutes
+
+# turn on actuator health check
+management.endpoint.health.enabled = true
+
+# allow to obtain basic information about camel routes (read only mode)
+management.endpoint.camelroutes.enabled = true
+management.endpoint.camelroutes.read-only = true
+
+# to configure logging levels
+#logging.level.org.springframework = INFO
+#logging.level.org.apache.camel.spring.boot = INFO
+#logging.level.org.apache.camel.impl = DEBUG
+#logging.level.sample.camel = DEBUG


### PR DESCRIPTION
This PR adds the following samples:
- Java application content for s2i java build usage. 
Code picked from: https://github.com/monodot/simple-camel-spring-boot-app/tree/master